### PR TITLE
Implement runtime check for AVX2 SIMD functionality in collisions

### DIFF
--- a/src_c/collisions.c
+++ b/src_c/collisions.c
@@ -201,8 +201,10 @@ pgIntersection_LineRect(pgLineBase *line, SDL_Rect *rect, double *X, double *Y,
                         double *T)
 {
 #if AVX2_IS_SUPPORTED
-    return pgIntersection_LineRect_avx2(line, rect, X, Y, T);
-#else
+    if (pg_HasAVX2())
+        return pgIntersection_LineRect_avx2(line, rect, X, Y, T);
+#endif /* ~__AVX2__ */
+
     double x = (double)rect->x;
     double y = (double)rect->y;
     double w = (double)rect->w;
@@ -237,15 +239,16 @@ pgIntersection_LineRect(pgLineBase *line, SDL_Rect *rect, double *X, double *Y,
     }
 
     return ret;
-#endif /* ~__AVX2__ */
 }
 
 static int
 pgCollision_RectLine(SDL_Rect *rect, pgLineBase *line)
 {
 #if AVX2_IS_SUPPORTED
-    return pgCollision_RectLine_avx2(rect, line);
-#else
+    if (pg_HasAVX2())
+        return pgCollision_RectLine_avx2(rect, line);
+#endif /* ~__AVX2__ */
+
     double x = (double)rect->x;
     double y = (double)rect->y;
     double w = (double)rect->w;
@@ -258,7 +261,6 @@ pgCollision_RectLine(SDL_Rect *rect, pgLineBase *line)
 
     return pgCollision_LineLine(line, &a) || pgCollision_LineLine(line, &b) ||
            pgCollision_LineLine(line, &c) || pgCollision_LineLine(line, &d);
-#endif /* ~__AVX2__ */
 }
 
 static int
@@ -361,8 +363,10 @@ static int
 pgRaycast_LineRect(pgLineBase *line, SDL_Rect *rect, double max_t, double *T)
 {
 #if AVX2_IS_SUPPORTED
-    return pgRaycast_LineRect_avx2(line, rect, max_t, T);
-#else
+    if (pg_HasAVX2())
+        return pgRaycast_LineRect_avx2(line, rect, max_t, T);
+#endif /* ~__AVX2__ */
+
     double x = (double)rect->x;
     double y = (double)rect->y;
     double w = (double)rect->w;
@@ -392,7 +396,6 @@ pgRaycast_LineRect(pgLineBase *line, SDL_Rect *rect, double max_t, double *T)
     }
 
     return ret;
-#endif /* ~__AVX2__ */
 }
 
 static int

--- a/src_c/simd_collisions.h
+++ b/src_c/simd_collisions.h
@@ -20,6 +20,9 @@
 #endif /* ~defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
           !defined(SDL_DISABLE_IMMINTRIN_H) */
 
+PG_FORCEINLINE static int
+pg_HasAVX2(void);
+
 #ifdef AVX2_IS_SUPPORTED
 PG_FORCEINLINE static int
 pgIntersection_LineRect_avx2(pgLineBase *line, SDL_Rect *rect, double *X,

--- a/src_c/simd_collisions_avx2.c
+++ b/src_c/simd_collisions_avx2.c
@@ -1,9 +1,53 @@
 #include "include/pygame.h"
 #include "simd_collisions.h"
+#include <string.h>
+
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
 
 #if defined(HAVE_IMMINTRIN_H) && !defined(SDL_DISABLE_IMMINTRIN_H)
 #include <immintrin.h>
 #endif /* defined(HAVE_IMMINTRIN_H) && !defined(SDL_DISABLE_IMMINTRIN_H) */
+
+PG_FORCEINLINE static int
+pg_HasAVX2(void)
+{
+    // The check is cached.
+    static int has_avx2 = -1;
+    if (has_avx2 != -1)
+        return has_avx2;
+
+#if AVX2_IS_SUPPORTED
+#if defined(__GNUC__)
+    // Reference:
+    // https://gcc.gnu.org/onlinedocs/gcc-4.8.2/gcc/X86-Built-in-Functions.html
+    has_avx2 = __builtin_cpu_supports("avx2");
+#elif defined(_MSC_VER)
+    // Reference:
+    // https://learn.microsoft.com/en-us/cpp/intrinsics/cpuid-cpuidex?view=msvc-170
+
+    int cpu_info[4];
+    __cpuid(cpu_info, 0);
+
+    int info_n = cpu_info[0];
+    int data[info_n][4];
+
+    for (int i = 0; i <= info_n; i++) {
+        __cpuidex(cpu_info, i, 0);
+        memcpy(&data[i], cpu_info, sizeof(int) * 4);
+    }
+
+    has_avx2 = data[7][1] >> 5 & 1;
+#else
+    has_avx2 = 0;
+#endif
+#else
+    has_avx2 = 0;
+#endif /* ~__AVX2__ */
+
+    return has_avx2;
+}
 
 #if AVX2_IS_SUPPORTED
 PG_FORCEINLINE static int


### PR DESCRIPTION
This PR implements a runtime check on whether the AVX2 instruction set is present or not in the CPU. Compile-time macros like `__AVX2__` only flags whether the compiler support generating code using AVX2, but not whether the running system would be able to execute it. If a non-AVX2-supporting processor runs an AVX2-using code, the program will generate a segfault over an unrecognized instruction/opcode, as what I intend to fix #202. Because pygame-geometry doesn't use SDL2, which means not being able to use the straightforward `SDL_HasAVX2` function, I had to make my own function to check it.