### PR TITLE
Added polygon to Circle and Line collideswith

### DIFF
--- a/docs/circle.rst
+++ b/docs/circle.rst
@@ -272,6 +272,7 @@ Circle Methods
         | :sg:`collideswith(Line) -> bool`
         | :sg:`collideswith(Circle) -> bool`
         | :sg:`collideswith(Rect) -> bool`
+        | :sg:`collideswith(Polygon) -> bool`
         | :sg:`collideswith((x, y)) -> bool`
         | :sg:`contains(Vector2) -> bool`
 

--- a/docs/circle.rst
+++ b/docs/circle.rst
@@ -285,12 +285,16 @@ Circle Methods
 
         .. note::
             It is important to note that the shape must be an actual shape object, such as
-            a `Line`, `Circle`, or `Rect` instance. It is not possible to pass a tuple
+            a `Line`, `Circle`, `Polygon`, or `Rect` instance. It is not possible to pass a tuple
             or list of coordinates representing the shape as an argument(except for a point),
             because the type of shape represented by the coordinates cannot be determined.
             For example, a tuple with the format (a, b, c, d) could represent either a `Line`
             or a Rect object, and there is no way to determine which is which without explicitly
             passing a `Line` or `Rect` object as an argument.
+
+         .. note::
+            Collisions with a `Polygon` object are evaluated the same way the :meth:`collidepolygon`
+            method does by default, meaning with only_edges set to `False`.
 
       .. ## Circle.collideswith ##
 

--- a/docs/line.rst
+++ b/docs/line.rst
@@ -364,7 +364,11 @@ Line Methods
             If a shape is passed it must be an actual single shape object. It cannot be a
             tuple or list of coordinates that represent the shape. This is because there
             is no way to determine what type of shape the coordinates represent.
-        
+
+        .. note::
+            Collisions with a `Polygon` object are evaluated the same way the :meth:`collidepolygon`
+            method does by default, meaning with only_edges set to `False`.
+
       .. ## Line.collideswith ##
 
 

--- a/docs/line.rst
+++ b/docs/line.rst
@@ -350,13 +350,14 @@ Line Methods
         | :sg:`collideswith(Line) -> bool`
         | :sg:`collideswith(Circle) -> bool`
         | :sg:`collideswith(Rect) -> bool`
+        | :sg:`collideswith(Polygon) -> bool`
         | :sg:`collideswith((x, y)) -> bool`
         | :sg:`contains(Vector2) -> bool`
 
         Returns `True` if any portion of the shape or point overlaps with the Line,
         `False` otherwise. This is a general alternative to the collision problem as it can
         be used to test for collisions with any shape or point. The shape can be a
-        Line, Circle, or Rect. The point can be a tuple or list containing the x and y
+        `Line`, `Circle`, `Polygon`, or `Rect`. The point can be a tuple or list containing the x and y
         coordinates of the point or a Vector2.
 
         .. note::

--- a/geometry.pyi
+++ b/geometry.pyi
@@ -37,7 +37,7 @@ class _HasLineAttribute(Protocol):
 LineValue = Union[_CanBeLine, _HasLineAttribute]
 
 _CanBeCircle = Union[Vector3, Circle, Tuple[float, float, float], Sequence[float]]
-_CanBeCollided = Union[Circle, Rect, Line, Sequence[int, int]]
+_CanBeCollided = Union[Circle, Rect, Line, Polygon, Sequence[int, int]]
 
 class _HasCirclettribute(Protocol):
     # An object that has a circle attribute that is either a circle, or a function

--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -334,6 +334,10 @@ pg_circle_collideswith(pgCircleObject *self, PyObject *arg)
     else if (pgLine_Check(arg)) {
         result = pgCollision_LineCircle(&pgLine_AsLine(arg), scirc);
     }
+    else if (pgPolygon_Check(arg)) {
+        result =
+            pgCollision_CirclePolygon(scirc, &pgPolygon_AsPolygon(arg), 0);
+    }
     else if (PySequence_Check(arg)) {
         double x, y;
         if (!pg_TwoDoublesFromObj(arg, &x, &y)) {
@@ -346,7 +350,7 @@ pg_circle_collideswith(pgCircleObject *self, PyObject *arg)
     else {
         return RAISE(PyExc_TypeError,
                      "Invalid shape argument, must be a CircleType, RectType, "
-                     "LineType or a sequence of 2 numbers");
+                     "LineType, PolygonType or a sequence of 2 numbers");
     }
 
     return PyBool_FromLong(result);

--- a/test/test_circle.py
+++ b/test/test_circle.py
@@ -699,6 +699,14 @@ class CircleTypeTest(unittest.TestCase):
         self.assertTrue(c.collideswith(p), E_T + "point should collide here")
         self.assertFalse(c.collideswith(p2), E_F + "point should not collide here")
 
+        #polygon
+        c4 = Circle(0, 0, 15)
+        po1 = Polygon([(-5, 0), (5, 0), (0, 5)])
+        po2 = Polygon([(100, 150), (200, 225), (150, 200)])
+
+        self.assertTrue(c.collideswith(po1), E_T + "polygon should collide here")
+        self.assertFalse(c.collideswith(po2), E_F + "polygon should not collide here")
+
     def test_as_rect_invalid_args(self):
         c = Circle(0, 0, 10)
 

--- a/test/test_circle.py
+++ b/test/test_circle.py
@@ -699,7 +699,7 @@ class CircleTypeTest(unittest.TestCase):
         self.assertTrue(c.collideswith(p), E_T + "point should collide here")
         self.assertFalse(c.collideswith(p2), E_F + "point should not collide here")
 
-        #polygon
+        # polygon
         c4 = Circle(0, 0, 15)
         po1 = Polygon([(-5, 0), (5, 0), (0, 5)])
         po2 = Polygon([(100, 150), (200, 225), (150, 200)])

--- a/test/test_line.py
+++ b/test/test_line.py
@@ -559,7 +559,7 @@ class LineTypeTest(unittest.TestCase):
 
         # polygon
         l4 = Line(0, 0, 10, 10)
-        po1 = regular_polygon(4, l4.midpoint, 100)
+        po1 = regular_polygon(4, l4.center, 100)
         po2 = Polygon((100, 100), (150, 150), (150, 100))
         po3 = regular_polygon(4, l4.a, 10)
         po4 = Polygon((5, 5), (5, 10), (0, 10), (2.5, 2.5))

--- a/test/test_line.py
+++ b/test/test_line.py
@@ -557,6 +557,20 @@ class LineTypeTest(unittest.TestCase):
         self.assertTrue(c.collideswith(p), E_T + "point should collide here")
         self.assertFalse(c.collideswith(p2), E_F + "point should not collide here")
 
+        # polygon
+        l4 = Line(0, 0, 10, 10)
+        po1 = regular_polygon(4, l4.midpoint, 100)
+        po2 = Polygon((100, 100), (150, 150), (150, 100))
+        po3 = regular_polygon(4, l4.a, 10)
+        po4 = Polygon((5, 5), (5, 10), (0, 10), (2.5, 2.5))
+        po5 = Polygon((0, 0), (0, 10), (-5, 10), (-5, 0))
+
+        self.assertTrue(l4.collideswith(po1))
+        self.assertFalse(l4.collideswith(po2))
+        self.assertTrue(l4.collideswith(po3))
+        self.assertTrue(l4.collideswith(po4))
+        self.assertTrue(l4.collideswith(po5))
+
     def test_meth_copy(self):
         line = Line(1, 2, 3, 4)
         # check 1 arg passed
@@ -1218,7 +1232,7 @@ class LineTypeTest(unittest.TestCase):
             with self.assertRaises(TypeError):
                 l.collidepolygon(poly, value)
 
-    def test_collideline(self):
+    def test_collidepolygon(self):
         """Ensures that the collidepolygon method correctly determines if a Polygon
         is colliding with the Line"""
 
@@ -1230,36 +1244,36 @@ class LineTypeTest(unittest.TestCase):
         p5 = Polygon((0, 0), (0, 10), (-5, 10), (-5, 0))
 
         # line inside polygon
-        self.assertTrue(p1.collideline(l))
+        self.assertTrue(l.collidepolygon(p1))
 
         # line outside polygon
-        self.assertFalse(p2.collideline(l))
+        self.assertFalse(l.collidepolygon(p2))
 
         # line intersects polygon edge
-        self.assertTrue(p3.collideline(l))
+        self.assertTrue(l.collidepolygon(p3))
 
         # line intersects polygon vertex
-        self.assertTrue(p4.collideline(l))
+        self.assertTrue(l.collidepolygon(p4))
 
         # line touches polygon vertex
-        self.assertTrue(p5.collideline(l))
+        self.assertTrue(l.collidepolygon(p5))
 
         # --- Edge only ---
 
         # line inside polygon
-        self.assertFalse(p1.collideline(l, True))
+        self.assertFalse(l.collidepolygon(p1, True))
 
         # line outside polygon
-        self.assertFalse(p2.collideline(l, True))
+        self.assertFalse(l.collidepolygon(p2, True))
 
         # line intersects polygon edge
-        self.assertTrue(p3.collideline(l, True))
+        self.assertTrue(l.collidepolygon(p3, True))
 
         # line intersects polygon vertex
-        self.assertTrue(p4.collideline(l, True))
+        self.assertTrue(l.collidepolygon(p4, True))
 
         # line touches polygon vertex
-        self.assertTrue(p5.collideline(l, True))
+        self.assertTrue(l.collidepolygon(p5, True))
 
     def test_meth_as_points(self):
         """Test the as_points method."""


### PR DESCRIPTION
Now both Circle and Line's `collideswith` method will accept polygons. This PR also corrects line collidepolygon tests and adds new ones to accommodate for the changes. It comes with a caveat that is the collideswith method will only work as if the "only_edges" param were set to False. This is because for now collideswith is intended to be a function with a single argument so i had to enforce one behaviour.