### PR TITLE
Fix line rotate

### DIFF
--- a/src_c/line.c
+++ b/src_c/line.c
@@ -754,8 +754,8 @@ _pg_rotate_line_helper(pgLineBase *line, double angle, double rx, double ry)
 
     double angle_rad = DEG_TO_RAD(angle);
 
-    double x1 = line->x1, y1 = line->y1;
-    double x2 = line->x2, y2 = line->y2;
+    double x1 = line->xa, y1 = line->ya;
+    double x2 = line->xb, y2 = line->yb;
 
     double cos_a = cos(angle_rad);
     double sin_a = sin(angle_rad);
@@ -770,11 +770,11 @@ _pg_rotate_line_helper(pgLineBase *line, double angle, double rx, double ry)
     double x2_new = x2 * cos_a - y2 * sin_a;
     double y2_new = x2 * sin_a + y2 * cos_a;
 
-    line->x1 = x1_new + rx;
-    line->y1 = y1_new + ry;
+    line->xa = x1_new + rx;
+    line->ya = y1_new + ry;
 
-    line->x2 = x2_new + rx;
-    line->y2 = y2_new + ry;
+    line->xb = x2_new + rx;
+    line->yb = y2_new + ry;
 }
 
 static PyObject *
@@ -787,8 +787,8 @@ pg_line_rotate(pgLineObject *self, PyObject *const *args, Py_ssize_t nargs)
     pgLineBase *line = &self->line;
     double angle, rx, ry;
 
-    rx = (line->x1 + line->x2) / 2;
-    ry = (line->y1 + line->y2) / 2;
+    rx = (line->xa + line->xb) / 2;
+    ry = (line->ya + line->yb) / 2;
 
     if (!pg_DoubleFromObj(args[0], &angle)) {
         return RAISE(PyExc_TypeError,
@@ -821,8 +821,8 @@ pg_line_rotate_ip(pgLineObject *self, PyObject *const *args, Py_ssize_t nargs)
     pgLineBase *line = &self->line;
     double angle, rx, ry;
 
-    rx = (line->x1 + line->x2) / 2;
-    ry = (line->y1 + line->y2) / 2;
+    rx = (line->xa + line->xb) / 2;
+    ry = (line->ya + line->yb) / 2;
 
     if (!pg_DoubleFromObj(args[0], &angle)) {
         return RAISE(PyExc_TypeError,

--- a/test/test_line.py
+++ b/test/test_line.py
@@ -1520,10 +1520,10 @@ class LineTypeTest(unittest.TestCase):
             return Line(x1, y1, x2, y2)
 
         def assert_approx_equal(line1, line2, eps=1e-12):
-            self.assertAlmostEqual(line1.x1, line2.x1, delta=eps)
-            self.assertAlmostEqual(line1.y1, line2.y1, delta=eps)
-            self.assertAlmostEqual(line1.x2, line2.x2, delta=eps)
-            self.assertAlmostEqual(line1.y2, line2.y2, delta=eps)
+            self.assertAlmostEqual(line1.xa, line2.xa, delta=eps)
+            self.assertAlmostEqual(line1.ya, line2.ya, delta=eps)
+            self.assertAlmostEqual(line1.xb, line2.xb, delta=eps)
+            self.assertAlmostEqual(line1.yb, line2.yb, delta=eps)
 
         l = Line(0, 0, 1, 1)
         angles = float_range(-360, 360, 0.5)
@@ -1555,10 +1555,10 @@ class LineTypeTest(unittest.TestCase):
             return Line(x1, y1, x2, y2)
 
         def assert_approx_equal(line1, line2, eps=1e-12):
-            self.assertAlmostEqual(line1.x1, line2.x1, delta=eps)
-            self.assertAlmostEqual(line1.y1, line2.y1, delta=eps)
-            self.assertAlmostEqual(line1.x2, line2.x2, delta=eps)
-            self.assertAlmostEqual(line1.y2, line2.y2, delta=eps)
+            self.assertAlmostEqual(line1.xa, line2.xa, delta=eps)
+            self.assertAlmostEqual(line1.ya, line2.ya, delta=eps)
+            self.assertAlmostEqual(line1.xb, line2.xb, delta=eps)
+            self.assertAlmostEqual(line1.yb, line2.yb, delta=eps)
 
         l = Line(0, 0, 1, 1)
         angles = float_range(-360, 360, 0.5)


### PR DESCRIPTION
```Py
from geometry import Line
import pygame


def main():
    pygame.init()

    line = Line((100, 100), (700, 700))

    screen = pygame.display.set_mode((800, 800))
    clock = pygame.time.Clock()

    keep = True
    clicked = False

    rot_point = line.center

    while keep:
        dt = clock.tick_busy_loop(60)

        if clicked:
            line.rotate_ip(dt, rot_point)

        screen.fill((0, 0, 0))

        pygame.draw.line(screen, (255, 255, 255), line.a, line.b)
        pygame.draw.circle(screen, (255, 0, 0), rot_point, 5)

        pygame.display.flip()

        for event in pygame.event.get():
            if event.type == pygame.QUIT:
                keep = False
            elif event.type == pygame.MOUSEBUTTONDOWN:
                clicked = True
            elif event.type == pygame.MOUSEBUTTONUP:
                clicked = False
                if event.button == 3:
                    rot_point = event.pos



if __name__ == "__main__":
    main()
```